### PR TITLE
fix generating principal apispecops.*interface{}

### DIFF
--- a/example2/swagger-templates/templates/server/handler.gotmpl
+++ b/example2/swagger-templates/templates/server/handler.gotmpl
@@ -5,6 +5,6 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 )
 
-func (srv *Service){{ pascalize .Name }}Handler(params api{{ pascalize .Package }}.{{ pascalize .Name }}Params{{ if .Authorized }}, principal api{{ .Package }}.{{ if not ( eq .Principal "interface{}" ) }}*{{ end }}{{ .Principal }}{{ end }}) middleware.Responder {
+func (srv *Service){{ pascalize .Name }}Handler(params api{{ pascalize .Package }}.{{ pascalize .Name }}Params{{ if .Authorized }},principal {{ if not ( eq .Principal "interface{}" ) }}api{{ .Package }}.*{{ end }}{{ .Principal }}{{ end }}) middleware.Responder {
 	return middleware.NotImplemented("operation {{ .Package }} {{ pascalize .Name }} has not yet been implemented")
 }


### PR DESCRIPTION
Исправляет ошибку, при которой генерируется аргумент  ", principal apispecops.*interface{}"

source formatting failed on template-generated source ("internal/app/gen_handlers/post_recommendations.go" for handlerFns). Check that your template produces valid code 2022/10/27 10:01:52 unformatted generated source "post_recommendations.go" has been dumped for template debugging purposes. DO NOT build on this source!
source formatting on generated source "handlerFns" failed: internal/app/gen_handlers/post_recommendations.go:8:112: expected 'IDENT', found '*'
make: *** [swagger-generate] Error 1